### PR TITLE
Add subscriptions

### DIFF
--- a/contracts/.vscode/settings.json
+++ b/contracts/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "solidity.compileUsingRemoteVersion": "v0.8.26+commit.8a97fa7a"
+}

--- a/contracts/contracts/CompanyWallet.sol
+++ b/contracts/contracts/CompanyWallet.sol
@@ -166,7 +166,10 @@ contract CompanyWallet is Ownable {
                 uint256 nextPayment = getCustomerSubscriptionNextPayment(customer, productId);
                 bool isActive = getCustomerSubscriptionStatus(customer, productId);
                 if (nextPayment <= block.timestamp && isActive) {
-                    ICustomerWallet(customer).payForSubscription(productId);
+                    bool success = ICustomerWallet(customer).payForSubscription(productId);
+                    if (success) {
+                        emit CustomerCharged(customer, productId);
+                    }
                 }
             }
         }

--- a/contracts/contracts/CompanyWallet.sol
+++ b/contracts/contracts/CompanyWallet.sol
@@ -100,9 +100,11 @@ contract CompanyWallet is Ownable {
         emit PaymentReceived(_customer, productsInfo[_productId].price);
     }
 
-    function addSubscription(address _customer, bytes32 _productId) external {
+    function addSubscription(address _customer, bytes32 _productId) payable external {
         require(productsInfo[_productId].available, "Product is not available");
         require(productsInfo[_productId].recurring, "Product is not recurring");
+        require(msg.value == productsInfo[_productId].price, "Invalid payment amount");
+        require(customerSubscriptionsStatus[_customer][_productId].isActive == false, "Subscription is already active");
         customerSubscriptions[_customer].push(_productId);
         CustomerSubscriptionInfo memory subscription = CustomerSubscriptionInfo({
             customer: _customer,
@@ -120,7 +122,7 @@ contract CompanyWallet is Ownable {
         emit CustomerUnsubscribed(_customer, _productId);
     }
 
-    function reactivateSubscription(address _customer, bytes32 _productId) external onlyOwner {
+    function reactivateSubscription(address _customer, bytes32 _productId) external payable {
         require(productsInfo[_productId].available, "Product is not available");
         require(productsInfo[_productId].recurring, "Product is not recurring");
         require(!customerSubscriptionsStatus[_customer][_productId].isActive, "Subscription is already active");

--- a/contracts/contracts/CompanyWallet.sol
+++ b/contracts/contracts/CompanyWallet.sol
@@ -11,6 +11,9 @@ contract CompanyWallet is Ownable {
     event ProductDisabled(bytes32 productId);
     event ProductEnabled(bytes32 productId);
     event PaymentReceived(address customer, uint256 amount);
+    event CustomerSubscribed(address customer, bytes32 productId);
+    event CustomerUnsubscribed(address customer, bytes32 productId);
+    event CustomerCharged(address customer, bytes32 productId);
 
     struct ProductInfo {
         uint256 price;
@@ -18,10 +21,28 @@ contract CompanyWallet is Ownable {
         string title; 
         string description;
         string imageUrl;
+        bool recurring;
+        uint256 interval;
+    }
+
+    struct CustomerSubscriptionInfo {
+        address customer;
+        bytes32 productId;
+        uint256 lastPayment;
+        uint256 nextPayment;
+        bool isActive;
+    }
+
+    struct CustomersCharged {
+        address customer;
+        bytes32 productId;
     }
 
     bytes32[] public productIds;
     mapping(bytes32 => ProductInfo) public productsInfo;
+    mapping(address => bytes32[]) public customerSubscriptions;
+    mapping(address => mapping(bytes32 => CustomerSubscriptionInfo)) public customerSubscriptionsStatus;
+
 
     constructor(
         address _owner
@@ -79,4 +100,45 @@ contract CompanyWallet is Ownable {
         emit PaymentReceived(_customer, productsInfo[_productId].price);
     }
 
+    function addSubscription(address _customer, bytes32 _productId) external {
+        require(productsInfo[_productId].available, "Product is not available");
+        require(productsInfo[_productId].recurring, "Product is not recurring");
+        customerSubscriptions[_customer].push(_productId);
+        CustomerSubscriptionInfo memory subscription = CustomerSubscriptionInfo({
+            customer: _customer,
+            productId: _productId,
+            lastPayment: block.timestamp,
+            nextPayment: block.timestamp + productsInfo[_productId].interval,
+            isActive: true
+        });
+        customerSubscriptionsStatus[_customer][_productId] = subscription;
+        emit CustomerSubscribed(_customer, _productId);
+    }
+
+    function cancelSubscription(address _customer, bytes32 _productId) external {
+        customerSubscriptionsStatus[_customer][_productId].isActive = false;
+        emit CustomerUnsubscribed(_customer, _productId);
+    }
+
+    function reactivateSubscription(address _customer, bytes32 _productId) external onlyOwner {
+        require(productsInfo[_productId].available, "Product is not available");
+        require(productsInfo[_productId].recurring, "Product is not recurring");
+        require(!customerSubscriptionsStatus[_customer][_productId].isActive, "Subscription is already active");
+        customerSubscriptionsStatus[_customer][_productId].isActive = true;
+        customerSubscriptionsStatus[_customer][_productId].lastPayment = block.timestamp;
+        customerSubscriptionsStatus[_customer][_productId].nextPayment = block.timestamp + productsInfo[_productId].interval;
+        emit CustomerSubscribed(_customer, _productId);
+    }
+
+    function getCustomerSubscriptions(address _customer) external view returns (bytes32[] memory) {
+        bytes32[] memory subscriptions = new bytes32[](customerSubscriptions[_customer].length);
+        for (uint i = 0; i < customerSubscriptions[_customer].length; i++) {
+            subscriptions[i] = customerSubscriptions[_customer][i];
+        }
+        return subscriptions;
+    }
+
+    function getCustomerSubscriptionStatus(address _customer, bytes32 _productId) external view returns (CustomerSubscriptionInfo memory) {
+        return customerSubscriptionsStatus[_customer][_productId];
+    }
 }

--- a/contracts/contracts/CustomerWallet.sol
+++ b/contracts/contracts/CustomerWallet.sol
@@ -7,12 +7,24 @@ interface ICompanyWallet {
     function getProductPrice(
         bytes32 _productId
     ) external view returns (uint256);
+    function addSubscription(
+        address _customer,
+        bytes32 _productId
+    ) external payable;
+    function cancelSubscription(address _customer, bytes32 _productId) external;
+    function reactivateSubscription(
+        address _customer,
+        bytes32 _productId
+    ) external payable;
 }
 
 contract CustomerWallet is Ownable {
     event Deposit(uint256 amount);
     event Withdrawal(uint256 amount);
     event OneTimePayment(address indexed company, uint256 amount);
+    event SubscriptionAdded(address indexed company, bytes32 productId);
+    event SubscriptionCancelled(address indexed company, bytes32 productId);
+    event SubscriptionReactivated(address indexed company, bytes32 productId);
 
     constructor(address _owner) Ownable(_owner) {}
 
@@ -47,6 +59,67 @@ contract CustomerWallet is Ownable {
             emit OneTimePayment(_companyContract, price);
         } catch {
             revert("Failed to make one time payment");
+        }
+    }
+
+    function addSubscription(
+        address _companyContract,
+        bytes32 _productId
+    ) public onlyOwner {
+        uint256 price = ICompanyWallet(_companyContract).getProductPrice(
+            _productId
+        );
+
+        require(price > 0, "Failed to retrieve price");
+        require(address(this).balance >= price, "Insufficient balance");
+
+        try
+            ICompanyWallet(_companyContract).addSubscription{value: price}(
+                address(this),
+                _productId
+            )
+        {
+            emit SubscriptionAdded(_companyContract, _productId);
+        } catch {
+            revert("Failed to add subscription");
+        }
+    }
+
+    function cancelSubscription(
+        address _companyContract,
+        bytes32 _productId
+    ) public onlyOwner {
+        try
+            ICompanyWallet(_companyContract).cancelSubscription(
+                address(this),
+                _productId
+            )
+        {
+            emit SubscriptionCancelled(_companyContract, _productId);
+        } catch {
+            revert("Failed to cancel subscription");
+        }
+    }
+
+    function reactivateSubscription(
+        address _companyContract,
+        bytes32 _productId
+    ) public onlyOwner {
+        uint256 price = ICompanyWallet(_companyContract).getProductPrice(
+            _productId
+        );
+
+        require(price > 0, "Failed to retrieve price");
+        require(address(this).balance >= price, "Insufficient balance");
+
+        try
+            ICompanyWallet(_companyContract).reactivateSubscription{
+                value: price
+            }(address(this), _productId)
+        {
+            emit SubscriptionReactivated(_companyContract, _productId);
+        } catch {
+            revert("Failed to reactivate subscription");
         }
     }
 }


### PR DESCRIPTION
Subscriptions have been added, BUT only first payment & reactivation payment are enabled at the moment.

Some improvements could be added, at least:

- Improve checks before modifying subscriptions (for example: if a subscription has been cancelled before next payment is due, do not charge the customer again if it reactivates the subscription before the next payment happens -> would lead to duplicate payments)
- Maybe issue refunds? 

Automatic payment for the subscriptions have not been added at the moment (working on it) -> DO NOT delete until this is done, but branch can be merged to handle the rest of the subscriptions part on the front end)